### PR TITLE
Sjm/configurable blocks

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,11 +1,11 @@
 var insteadUrl = chrome.extension.getURL( "instead.html" );
-var allowedUrls;
+var allowances;
 var blockedDomains;
 
-chrome.storage.sync.get( ["allowedUrls", "blockedDomains"], function(data) {
+chrome.storage.sync.get( ["allowances", "blockedDomains"], function(data) {
 
-  if( allowedUrls === undefined && data.allowedUrls !== undefined ) {
-    allowedUrls = data.allowedUrls;
+  if( allowances === undefined && data.allowances !== undefined ) {
+    allowances = data.allowances;
   }
 
   if( blockedDomains === undefined ) {
@@ -22,8 +22,8 @@ chrome.storage.sync.get( ["allowedUrls", "blockedDomains"], function(data) {
 });
 
 chrome.storage.onChanged.addListener(function(changes, namespace) {
-  if( changes.allowedUrls !== undefined ) {
-    allowedUrls = changes.allowedUrls.newValue;
+  if( changes.allowances !== undefined ) {
+    allowances = changes.allowances.newValue;
   }
 
   if( changes.blockedDomains !== undefined ) {
@@ -61,16 +61,21 @@ function shouldBlockUrl( url ) {
   var matches = url.match( domainRegex );
   var domain = matches[1];
 
-  // TODO: Save the pattern to allow not the block
   var blockData = findFirstBlockedDomain( domain );
   if( !blockData.block ) {
     return false;
   }
 
-  var now = new Date().valueOf();
+  if( allowances === undefined ) {
+    return true;
+  }
 
-  var data = allowedUrls && allowedUrls[domain];
-  if( data !== undefined && data.timeoutMs !== undefined && now < data.timeoutMs ) {
+  if( allowances.timeoutMs === undefined ) {
+    return true
+  }
+
+  var now = new Date().valueOf();
+  if( now < allowances.timeoutMs ) {
     return false;
   }
 

--- a/src/background.js
+++ b/src/background.js
@@ -9,7 +9,7 @@ chrome.storage.sync.get( ["allowedUrls", "blockedDomains"], function(data) {
   }
 
   if( blockedDomains === undefined ) {
-    if( data.blockedDomains ) {
+    if( data.blockedDomains !== undefined ) {
       blockedDomains = data.blockedDomains;
     } else {
       blockedDomains = {

--- a/src/background.js
+++ b/src/background.js
@@ -22,12 +22,13 @@ chrome.storage.sync.get( ["allowedUrls", "blockedDomains"], function(data) {
 });
 
 chrome.storage.onChanged.addListener(function(changes, namespace) {
-  var changedUrls = changes.allowedUrls
-  if( changedUrls === undefined ) {
-    return;
+  if( changes.allowedUrls !== undefined ) {
+    allowedUrls = changedUrls.allowedUrls.newValue;
   }
 
-  allowedUrls = changedUrls.newValue;
+  if( changes.blockedDomains !== undefined ) {
+    blockedDomains = changedUrls.allowedUrls.newValue;
+  }
 });
 
 var domainRegex = new RegExp( "://([^/]+)" );

--- a/src/background.js
+++ b/src/background.js
@@ -1,16 +1,24 @@
 var insteadUrl = chrome.extension.getURL( "instead.html" );
 var allowedUrls;
+var blockedDomains;
 
-chrome.storage.sync.get( "allowedUrls", function(data) {
-  if (allowedUrls) {
-    return;
-  }
-  var remoteUrls = data.allowedUrls;
-  if( remoteUrls === undefined ) {
-    return;
+chrome.storage.sync.get( ["allowedUrls", "blockedDomains"], function(data) {
+
+  if( allowedUrls === undefined && data.allowedUrls !== undefined ) {
+    allowedUrls = data.allowedUrls;
   }
 
-  allowedUrls = remoteUrls;
+  if( blockedDomains === undefined ) {
+    if( data.blockedDomains ) {
+      blockedDomains = data.blockedDomains;
+    } else {
+      blockedDomains = {
+        "facebook.com" : {},
+        "www.lolcats.com" : {},
+        "netflix.com" : {}
+      };
+    }
+  }
 });
 
 chrome.storage.onChanged.addListener(function(changes, namespace) {
@@ -23,15 +31,14 @@ chrome.storage.onChanged.addListener(function(changes, namespace) {
 });
 
 var domainRegex = new RegExp( "://([^/]+)" );
-var blockedDomains = {
-  "facebook.com" : {},
-  "www.lolcats.com" : {},
-  "netflix.com" : {}
-};
 
 function shouldBlockUrl( url ) {
   var alreadyRedirected = url.indexOf( insteadUrl ) !== -1;
   if( alreadyRedirected ) {
+    return false;
+  }
+
+  if( blockedDomains === undefined ) {
     return false;
   }
 

--- a/src/background.js
+++ b/src/background.js
@@ -23,11 +23,11 @@ chrome.storage.sync.get( ["allowedUrls", "blockedDomains"], function(data) {
 
 chrome.storage.onChanged.addListener(function(changes, namespace) {
   if( changes.allowedUrls !== undefined ) {
-    allowedUrls = changedUrls.allowedUrls.newValue;
+    allowedUrls = changes.allowedUrls.newValue;
   }
 
   if( changes.blockedDomains !== undefined ) {
-    blockedDomains = changedUrls.allowedUrls.newValue;
+    blockedDomains = changes.allowedUrls.newValue;
   }
 });
 

--- a/src/instead.js
+++ b/src/instead.js
@@ -6,7 +6,7 @@ function getParameterByName(name) {
   return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
 }
 
-var timeoutOffsetMs = 5 * 1000;
+var timeoutOffsetMs = 15 * 1000;
 
 var siteUrl = getParameterByName( "site" );
 

--- a/src/instead.js
+++ b/src/instead.js
@@ -16,17 +16,15 @@ var domain = matches[1];
 
 function goForward() {
 
-  chrome.storage.sync.get( "allowedUrls", function(data) {
-    var updatedUrls = data.allowedUrls;
-    if( updatedUrls === undefined ) {
-      updatedUrls = {};
+  chrome.storage.sync.get( "allowances", function(data) {
+    var allowances = data.allowances;
+    if( allowances === undefined ) {
+      allowances = {};
     }
 
-    updatedUrls[domain] = {
-      timeoutMs: new Date().valueOf() + timeoutOffsetMs
-    };
+    allowances.timeoutMs = new Date().valueOf() + timeoutOffsetMs;
 
-    chrome.storage.sync.set( { allowedUrls: updatedUrls }, function() {
+    chrome.storage.sync.set( { allowances: allowances }, function() {
       location.href = siteUrl;
     });
 


### PR DESCRIPTION
Shifting the format for how blocked domains are configured and how they are applied. Domains are now blocked based on a simple wildcard match to an item in a list.

I was also forced to switch to everything being allowed or denied. If the user proceeds to bad content then they are allowed any bad content for a short window. This is _much_ simpler than tracking individual urls or domains which are allowed through.
